### PR TITLE
feat: Adds ability to enable "persistence mode"

### DIFF
--- a/.versioning/changes/AWcLkKItAf.minor.md
+++ b/.versioning/changes/AWcLkKItAf.minor.md
@@ -1,0 +1,1 @@
+Adds a `-P` / `--persistence-mode` cmdline option to optionally enable "Persistence Mode" when the utility is invoked.

--- a/gpufanctl.1
+++ b/gpufanctl.1
@@ -66,3 +66,6 @@ this to a higher value carries a risk of physical damage due to overheating.
 Required when setting the \fB--max-temperature\fP above the default value. This acts
 as user acknowledgement of the risk of damage due to overheating.
 .TP
+\fB-P, --persistence-mode\fP
+Enable persistence mode.
+.TP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,6 +115,11 @@ auto app(gfc::Parameters const& params) -> void
 
     auto device = gfc::nvml::get_device_handle_by_index(0);
 
+    if (params.enable_persistence_mode) {
+        gfc::log(gfc::LogLevel::info, "Enabling persistence mode");
+        gfc::nvml::set_device_persistence_mode(device, NVML_FEATURE_ENABLED);
+    }
+
     auto const fan_count = gfc::nvml::get_device_fan_count(device);
     if (fan_count < 1) {
         throw std::runtime_error { "Device has no fans" };

--- a/src/nvml.cpp
+++ b/src/nvml.cpp
@@ -41,6 +41,9 @@ auto load_nvml() -> NVML
                       "nvmlDeviceSetDefaultFanSpeed_v2",
                       lib);
     TRY_ATTACH_SYMBOL(&nvml.nvmlDeviceGetNumFans, "nvmlDeviceGetNumFans", lib);
+    TRY_ATTACH_SYMBOL(&nvml.nvmlDeviceSetPersistenceMode,
+                      "nvmlDeviceSetPersistenceMode",
+                      lib);
 
     return nvml;
 }
@@ -52,7 +55,10 @@ auto lib() -> NVML const&
     return lib;
 }
 
-auto init() -> void { CHECK_NVML_RESULT(lib().nvmlInit_v2(), "init"); }
+auto init() -> void
+{
+    CHECK_NVML_RESULT(lib().nvmlInit_v2(), "init");
+}
 
 auto shutdown() noexcept -> void
 {
@@ -110,4 +116,10 @@ auto get_device_fan_count(nvmlDevice_t device) -> unsigned int
     return count;
 }
 
+auto set_device_persistence_mode(nvmlDevice_t device, nvmlEnableState_t state)
+    -> void
+{
+    CHECK_NVML_RESULT(lib().nvmlDeviceSetPersistenceMode(device, state),
+                      "set_device_persistence_mode");
+}
 } // namespace gfc::nvml

--- a/src/nvml.h
+++ b/src/nvml.h
@@ -141,6 +141,15 @@ typedef enum nvmlReturn_enum
 } nvmlReturn_t;
 
 /**
+ * Generic enable/disable enum.
+ */
+typedef enum nvmlEnableState_enum
+{
+    NVML_FEATURE_DISABLED = 0, //!< Feature disabled
+    NVML_FEATURE_ENABLED = 1   //!< Feature enabled
+} nvmlEnableState_t;
+
+/**
  * Temperature sensors.
  */
 typedef enum nvmlTemperatureSensors_enum
@@ -456,6 +465,51 @@ typedef nvmlReturn_t (*PFN_nvmlDeviceSetDefaultFanSpeed_v2)(nvmlDevice_t device,
  */
 typedef nvmlReturn_t (*PFN_nvmlDeviceGetNumFans)(nvmlDevice_t device,
                                                  unsigned int* numFans);
+
+/**
+ * Set the persistence mode for the device.
+ *
+ * For all products.
+ * For Linux only.
+ * Requires root/admin permissions.
+ *
+ * The persistence mode determines whether the GPU driver software is torn down
+ * after the last client exits.
+ *
+ * This operation takes effect immediately. It is not persistent across reboots.
+ * After each reboot the persistence mode is reset to "Disabled".
+ *
+ * See \ref nvmlEnableState_t for available modes.
+ *
+ * After calling this API with mode set to NVML_FEATURE_DISABLED on a device
+ * that has its own NUMA memory, the given device handle will no longer be
+ * valid, and to continue to interact with this device, a new handle should be
+ * obtained from one of the nvmlDeviceGetHandleBy*() APIs. This limitation is
+ * currently only applicable to devices that have a coherent NVLink connection
+ * to system memory.
+ *
+ * @param device                               The identifier of the target
+ * device
+ * @param mode                                 The target persistence mode
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the persistence mode was set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been
+ * successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a
+ * mode is invalid
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support
+ * this feature
+ *         - \ref NVML_ERROR_NO_PERMISSION     if the user doesn't have
+ * permission to perform this operation
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off
+ * the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceGetPersistenceMode()
+ */
+typedef nvmlReturn_t (*PFN_nvmlDeviceSetPersistenceMode)(
+    nvmlDevice_t device, nvmlEnableState_t mode);
 
 #ifdef __cplusplus
 }

--- a/src/nvml.hpp
+++ b/src/nvml.hpp
@@ -18,6 +18,7 @@ struct NVML
     PFN_nvmlDeviceSetFanSpeed_v2 nvmlDeviceSetFanSpeed_v2;
     PFN_nvmlDeviceSetDefaultFanSpeed_v2 nvmlDeviceSetDefaultFanSpeed_v2;
     PFN_nvmlDeviceGetNumFans nvmlDeviceGetNumFans;
+    PFN_nvmlDeviceSetPersistenceMode nvmlDeviceSetPersistenceMode;
 };
 
 auto lib() -> NVML const&;
@@ -35,6 +36,8 @@ auto set_device_fan_speed(nvmlDevice_t device,
 auto set_device_default_fan_speed(nvmlDevice_t device, unsigned int fan_index)
     -> void;
 auto get_device_fan_count(nvmlDevice_t device) -> unsigned int;
+auto set_device_persistence_mode(nvmlDevice_t device, nvmlEnableState_t state)
+    -> void;
 } // namespace gfc::nvml
 
 #endif // GPUFANCTL_NVML_HPP_INCLUDED

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -30,6 +30,8 @@ auto get_flag_description(Flags flag) noexcept -> char const*
         return R"#(Set the maximum temperature allowed to ARG. Default is 80)#";
     case Flags::force:
         return R"#(Required when setting the --max-temperature above the default value)#";
+    case Flags::persistence_mode:
+        return R"#(Enable persistence mode)#";
     }
 
     return "";

--- a/src/parameters.hpp
+++ b/src/parameters.hpp
@@ -30,6 +30,7 @@ enum class Flags
     no_pidfile,
     max_temperature,
     force,
+    persistence_mode,
 };
 
 FlagDefinition<Flags> const flag_defs[] = {
@@ -66,6 +67,11 @@ FlagDefinition<Flags> const flag_defs[] = {
       {},
       validation::is_integer<Flags>() },
     { Flags::force, 0, "force", FlagArgument::none },
+    { Flags::persistence_mode,
+      'P',
+      "persistence-mode",
+      FlagArgument::none,
+      { Flags::print_fan_curve } },
 };
 
 auto get_flag_description(Flags flag) noexcept -> char const*;
@@ -102,6 +108,7 @@ struct Parameters
     bool output_metrics { false };
     bool use_pidfile { true };
     std::size_t max_temperature { kDefaultMaxTemperature };
+    bool enable_persistence_mode { false };
 };
 
 template <typename T>
@@ -185,6 +192,10 @@ set_parameters(CmdLine<cmdline::Flags, Allocator> const& cmdline,
             ec = make_error_code(ErrorCodes::force_required_to_set_temperature);
             return false;
         }
+    }
+
+    if (cmdline.has_flag(cmdline::Flags::persistence_mode)) {
+        params.enable_persistence_mode = true;
     }
 
     return true;


### PR DESCRIPTION
The presence of a `-P` / `--persistence-mode` cmdline option will now enable "Persistence Mode" when the utility is started. This can seemingly be used to prevent excessive idle power usage.